### PR TITLE
If files already exists do not replace it

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -45,10 +45,20 @@ class InstallCommand extends Command
             mkdir(base_path('tests/Browser/screenshots'), 0755, true);
         }
 
-        copy(__DIR__.'/../../stubs/ExampleTest.stub', base_path('tests/Browser/ExampleTest.php'));
-        copy(__DIR__.'/../../stubs/HomePage.stub', base_path('tests/Browser/Pages/HomePage.php'));
-        copy(__DIR__.'/../../stubs/DuskTestCase.stub', base_path('tests/DuskTestCase.php'));
-        copy(__DIR__.'/../../stubs/Page.stub', base_path('tests/Browser/Pages/Page.php'));
+        if (! file_exists(base_path('tests/Browser/ExampleTest.php'))) {
+            copy(__DIR__.'/../../stubs/ExampleTest.stub', base_path('tests/Browser/ExampleTest.php'));
+        }
+
+        if (! file_exists(base_path('tests/Browser/Pages/HomePage.php'))) {
+            copy(__DIR__.'/../../stubs/HomePage.stub', base_path('tests/Browser/Pages/HomePage.php'));
+        }
+
+        if (! file_exists(base_path('tests/DuskTestCase.php'))) {
+            copy(__DIR__ . '/../../stubs/DuskTestCase.stub', base_path('tests/DuskTestCase.php'));
+        }
+        if (! file_exists(base_path('tests/Browser/Pages/Page.php'))) {
+            copy(__DIR__ . '/../../stubs/Page.stub', base_path('tests/Browser/Pages/Page.php'));
+        }
 
         file_put_contents(base_path('tests/Browser/screenshots/.gitignore'), '*
 !.gitignore


### PR DESCRIPTION
If you had modified ExampleTest.php, HomePage.php, DuskTestCase.php or Page.php and then run `dusk:install` to create ‘console’ folder, you will lose your progress in these modified files.

So this commit validates if each of them files exists to avoid replace it by the new one.